### PR TITLE
Change LanguageEncoding to appropriate value

### DIFF
--- a/xr6515dn.ppd
+++ b/xr6515dn.ppd
@@ -6,7 +6,7 @@
 
 *FileVersion: "5.519.0.0"
 *FormatVersion: "4.3"
-*LanguageEncoding: ISOLatin1
+*LanguageEncoding: UTF-8
 *LanguageVersion: German
 
 *Manufacturer: "Xerox"


### PR DESCRIPTION
If you clone the repo the actual fine encoding is UTF-8. This should be reflected by the LanguageEncoding entry in the PPD. 

Tested on debian 9: "Wei#" is now "Weiß" in cups settings.